### PR TITLE
Stop treating everything as Kotlin

### DIFF
--- a/syntaxes/codeblock.json
+++ b/syntaxes/codeblock.json
@@ -8,8 +8,8 @@
 	],
 	"repository": {
 		"kotlin-code-block": {
-          	"begin": "(^|\\G)(\\s*)(.*)",
-          	"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+			"begin": "(^|\\G)(\\s*)(.*)",
+			"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
 			"contentName": "meta.embedded.block.kotlin",
 			"patterns": [
 				{

--- a/syntaxes/codeblock.json
+++ b/syntaxes/codeblock.json
@@ -8,8 +8,8 @@
 	],
 	"repository": {
 		"kotlin-code-block": {
-			"begin": "(^|\\G)(\\s*)(.*)",
-			"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+			"begin": "(^|\\G)kotlin",
+			"end": "(^|\\G)(?=\\s*[`~]{3,}\\s*$)",
 			"contentName": "meta.embedded.block.kotlin",
 			"patterns": [
 				{

--- a/syntaxes/codeblock.json
+++ b/syntaxes/codeblock.json
@@ -8,8 +8,8 @@
 	],
 	"repository": {
 		"kotlin-code-block": {
-			"begin": "kotlin",
-			"end": "(^|\\G)(?=\\s*[`~]{3,}\\s*$)",
+          	"begin": "(^|\\G)(\\s*)(.*)",
+          	"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
 			"contentName": "meta.embedded.block.kotlin",
 			"patterns": [
 				{


### PR DESCRIPTION
In a markdown block, simply typing the word `kotlin` makes the rest of the file be a kotlin file. I used this portion of the official VS Code Markdown processing as a reference (this snippet handles C code):

```json
      "patterns": [
        {
          "begin": "(^|\\G)(\\s*)(.*)",
          "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
          "contentName": "meta.embedded.block.c",
          "patterns": [
            {
              "include": "source.c"
            }
          ]
        }
      ]
```